### PR TITLE
Fix: Serve static files from the 'public' folder

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,10 @@ app.use(morgan("combined", { stream: accessLogStream }));
 app.get('/', (req, res) => {
   res.send("Welcome to my api") 
 });
+
+// Serve static files from the 'public' folder
+app.use(express.static('public'));
+
 // CREATE - Add a user
 app.post('/users',
   // Validation logic here for request


### PR DESCRIPTION
To access a static HTML page in a public folder using Express, you can use the express.static middleware. The express.static middleware is built-in to Express and allows you to serve static files (such as HTML, CSS, JS, images, etc.) from a specified directory.

Here's how you can do it:

Place your static HTML file (e.g., index.html) inside a public folder in your project directory.

Modify your app.js (or whatever your main server file is called) to include the express.static middleware and serve the static files from the public folder:

```js
const express = require('express');
const app = express();

// Serve static files from the 'public' folder
app.use(express.static('public'));

// Start the server
```